### PR TITLE
Backport authorize code from master use vault token

### DIFF
--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -37,7 +37,14 @@ module Spree
 
     def authorize(money, creditcard, options = {})
       adjust_options_for_braintree(creditcard, options)
-      payment_method = creditcard.gateway_customer_profile_id || creditcard
+
+      if creditcard.gateway_payment_profile_id
+        payment_method = creditcard.gateway_payment_profile_id
+        options[:payment_method_token] = true
+      else
+        payment_method = creditcard.gateway_customer_profile_id || creditcard
+      end
+
       provider.authorize(money, payment_method, options)
     end
 


### PR DESCRIPTION
Current implementation will result in a transaction error since CVV requires to be re-entered when customer token instead of profile token is used. Related to [dotandbo_spree/#3122](https://github.com/dotandbo/dotandbo-spree/issues/3122).
